### PR TITLE
Add option to the playback actions to control if they should "alwaysRefire"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var instance_skel = require('../../instance_skel');
 
 /**
- * Companion instance class for Ross Video Xpression.
+ * Companion instance class for Avolites Titan.
  *
  * @extends instance_skel
  * @since 1.0.0
@@ -12,7 +12,7 @@ var instance_skel = require('../../instance_skel');
 class instance extends instance_skel {
 
 	/**
-	 * Create an instance of an Xpression module.
+	 * Create an instance of an Titan module.
 	 *
 	 * @param {EventEmitter} system - the brains of the operation
 	 * @param {string} id - the instance ID

--- a/index.js
+++ b/index.js
@@ -75,6 +75,13 @@ class instance extends instance_skel {
 			max: 9999
 		};
 
+		this.FIELD_ALWAYSREFIRE = {
+			type: 'checkbox',
+			label: 'Always Refire',
+			id: 'refire',
+			default: true
+		}
+
 		this.actions(); // export actions
 		this.initFeedbacks();
 	}
@@ -93,19 +100,21 @@ class instance extends instance_skel {
 				label: 'Playback @ Percentage',
 				options: [
 					this.FIELD_USERNUMBER,
-					this.FIELD_PERCENTAGE
+					this.FIELD_PERCENTAGE,
+					this.FIELD_ALWAYSREFIRE
 				],
 				callback: (action) => {
 					var percentage = action.options.percentage;
 					percentage = percentage/100;
-					this.sendCommand("script/2/Playbacks/FirePlaybackAtLevel?handle_userNumber=" + action.options.un + "&level_level=" + percentage + "&alwaysRefire=true");
+					this.sendCommand("script/2/Playbacks/FirePlaybackAtLevel?handle_userNumber=" + action.options.un + "&level_level=" + percentage + "&alwaysRefire=" + action.options.refire ?? true);
 				}
 			},
 			'playbackFlash': {
 				label: 'Playback Flash',
 				options: [
 					this.FIELD_USERNUMBER,
-					this.FIELD_PLAYBACKACTION
+					this.FIELD_PLAYBACKACTION,
+					this.FIELD_ALWAYSREFIRE
 				],
 				callback: (action) => {
 					var percentage = "1";
@@ -113,7 +122,7 @@ class instance extends instance_skel {
 					{
 						percentage = "0";
 					}
-					this.sendCommand("script/2/Playbacks/FirePlaybackAtLevel?handle_userNumber=" + action.options.un + "&level_level=" + percentage + "&alwaysRefire=true");
+					this.sendCommand("script/2/Playbacks/FirePlaybackAtLevel?handle_userNumber=" + action.options.un + "&level_level=" + percentage + "&alwaysRefire=" + action.options.refire ?? true);
 				}
 			},
 			'playbackSwop': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "avolites-titan",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"api_version": "1.0.0",
 	"description": "module for controlling avolites titan desks",
 	"main": "index.js",


### PR DESCRIPTION
Currently, the 2 playback actions assume the user would always want to re-fire the cue.

This PR adds a config option to allow the user to decide if the cue should be re-fired or not. This new option is implemented with a default value of `true` so that the old behavior is maintained as the default.